### PR TITLE
update resource limits for agents-operator

### DIFF
--- a/agents-operator-chart/values.yaml
+++ b/agents-operator-chart/values.yaml
@@ -46,11 +46,11 @@ clusterRoleBinding:
 
 resources:
   requests:
-    cpu: 10m
-    memory: 50Mi
-  limits:
     cpu: 100m
     memory: 100Mi
+  limits:
+    cpu: 500m
+    memory: 500Mi
 
 
 volumesMounts:

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -120,11 +120,11 @@ spec:
             value: "https://USERNAME:PASSWORD@agents.accuknox.com/repository/accuknox-agents-dev"
         resources:
           requests:
-            cpu: 10m
-            memory: 50Mi
-          limits:
             cpu: 100m
             memory: 100Mi
+          limits:
+            cpu: 500m
+            memory: 500Mi
         volumeMounts:
           - mountPath: /conf
             name: config-volume


### PR DESCRIPTION
Increasing the agents-operator resource limits as we are observing a spike in it's memory and CPU utilization whenever other agents restarts. 