### PR TITLE
use configmap informers and deployment listers

### DIFF
--- a/agents-operator-chart/values.yaml
+++ b/agents-operator-chart/values.yaml
@@ -46,8 +46,8 @@ clusterRoleBinding:
 
 resources:
   requests:
-    cpu: 100m
-    memory: 100Mi
+    cpu: 50m
+    memory: 50Mi
   limits:
     cpu: 500m
     memory: 500Mi

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -120,8 +120,8 @@ spec:
             value: "https://USERNAME:PASSWORD@agents.accuknox.com/repository/accuknox-agents-dev"
         resources:
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 50m
+            memory: 50Mi
           limits:
             cpu: 500m
             memory: 500Mi


### PR DESCRIPTION
The configmap watcher was resulting in some memory leaks issue, this PR adds configmap informer and deployment listers for checking any configmap and deployment changes 